### PR TITLE
Refactor into agentlib package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# agent
-Тest agent creation
+# Universal LangChain Agent
+
+Этот проект демонстрирует работу простого агента на базе LangChain.
+Агент расширяем и предоставляет CLI и HTTP API.
+
+## Требования
+
+- Python 3.11+
+- Переменная окружения `OPENAI_API_KEY` для доступа к ChatOpenAI
+
+Установите зависимости:
+
+```bash
+pip install langchain langchain-openai langchain-community \
+    langchain-experimental requests fastapi uvicorn
+```
+
+## Запуск CLI
+
+```bash
+python universal_agent.py
+```
+
+Для выхода введите `exit` или `quit`.
+
+## Запуск API
+
+```bash
+python universal_agent.py --api
+```
+
+HTTP сервер будет запущен на `http://127.0.0.1:8000`. POST запрос на `/chat`
+принимает JSON вида `{"input": "ваш вопрос"}` и возвращает ответ агента.
+
+## Встроенные инструменты
+
+- **Калькулятор** для математических выражений
+- **Приветствие** (пример пользовательской функции)
+- **REST API**: GET‑запрос по URL
+- **Чтение файлов** из локальной файловой системы
+- **Python REPL** для выполнения кода
+
+## Расширение
+
+Добавляйте свои инструменты в модуле `agentlib/tools.py` и
+подключайте их при сборке агента.

--- a/agentlib/api.py
+++ b/agentlib/api.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from langchain.agents import AgentExecutor
+
+
+class Query(BaseModel):
+    input: str
+
+
+def create_app(agent: AgentExecutor) -> FastAPI:
+    """Создает FastAPI приложение для взаимодействия с агентом."""
+    app = FastAPI()
+
+    @app.post("/chat")
+    async def chat(query: Query):
+        try:
+            result = agent.invoke({"input": query.input})
+            return {"output": result["output"]}
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+
+    return app

--- a/agentlib/builder.py
+++ b/agentlib/builder.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Sequence
+from langchain import hub
+from langchain_openai import ChatOpenAI
+from langchain.agents import AgentExecutor, create_react_agent
+
+
+def build_agent(tools: Sequence) -> AgentExecutor:
+    """Создает и возвращает LangChain агент."""
+    llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+    prompt = hub.pull("hwchase17/react")
+    agent = create_react_agent(llm, tools, prompt)
+    return AgentExecutor(agent=agent, tools=tools, verbose=True)

--- a/agentlib/cli.py
+++ b/agentlib/cli.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from langchain.agents import AgentExecutor
+
+
+def run_cli(agent: AgentExecutor) -> None:
+    """Запускает простой CLI для общения с агентом."""
+    print("Введите запрос (или 'exit' для выхода):")
+    while True:
+        user_input = input(" > ")
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        try:
+            response = agent.invoke({"input": user_input})
+            print(response["output"])
+        except Exception as exc:
+            print(f"Ошибка при обработке запроса: {exc}")

--- a/agentlib/tools.py
+++ b/agentlib/tools.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import requests
+from langchain.tools import tool
+from langchain_experimental.tools.python.tool import PythonREPLTool
+
+
+@tool
+def calculate(expression: str) -> str:
+    """Вычисляет математическое выражение."""
+    try:
+        result = eval(expression, {"__builtins__": {}})
+        return str(result)
+    except Exception as exc:
+        return f"Ошибка вычисления: {exc}"
+
+
+@tool
+def greet(name: str) -> str:
+    """Возвращает приветствие для указанного имени."""
+    return f"Привет, {name}!"
+
+
+@tool
+def call_api(url: str) -> str:
+    """Отправляет GET-запрос по указанному URL."""
+    try:
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        return r.text[:1000]
+    except Exception as exc:
+        return f"Ошибка API: {exc}"
+
+
+@tool
+def read_file(path: str) -> str:
+    """Читает файл и возвращает его содержимое."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception as exc:
+        return f"Ошибка чтения файла: {exc}"
+
+
+def get_default_tools():
+    """Возвращает список инструментов по умолчанию."""
+    python_repl = PythonREPLTool()
+    return [calculate, greet, call_api, read_file, python_repl]

--- a/universal_agent.py
+++ b/universal_agent.py
@@ -1,0 +1,31 @@
+"""Точка входа для запуска агента через CLI или API."""
+
+from __future__ import annotations
+
+import argparse
+
+from agentlib.builder import build_agent
+from agentlib.tools import get_default_tools
+from agentlib.cli import run_cli
+from agentlib.api import create_app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Universal LangChain Agent")
+    parser.add_argument("--api", action="store_true", help="Запустить HTTP API вместо CLI")
+    args = parser.parse_args()
+
+    tools = get_default_tools()
+    agent = build_agent(tools)
+
+    if args.api:
+        import uvicorn
+
+        app = create_app(agent)
+        uvicorn.run(app, host="127.0.0.1", port=8000)
+    else:
+        run_cli(agent)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- split agent functionality into `agentlib` package with CLI, API, tools, and builder
- keep `universal_agent.py` as a small entrypoint using the package
- update README to reference `agentlib/tools.py`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687393fd81a48321b22d3fe56cc43483